### PR TITLE
Fixed release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -16,6 +16,8 @@ jobs:
     steps:
       - name: Checkout repository
         uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
 
       - name: Generate release version
         id: semver
@@ -25,6 +27,7 @@ jobs:
           tag_prefix: "v"
           major_pattern: "^(feat|fix|refactor)!:"
           minor_pattern: "^feat:"
+          search_commit_body: true
 
       - name: Log generated version
         run: echo "Version is ${{ steps.semver.outputs.version }}"


### PR DESCRIPTION
checkout needs `fetch-depth: 0` to get tagging information...

### 📝 Description

[semantic-version README - Important Note](https://github.com/PaulHatch/semantic-version?tab=readme-ov-file#important-note-regarding-the-checkout-action)
