### PR TITLE
Fixed release workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -51,7 +51,7 @@ jobs:
       - name: Create GitHub release
         uses: softprops/action-gh-release@v2
         with:
-          tag_name: ${{ steps.semver.outputs.version }}
-          name: Release ${{ steps.semver.outputs.version }}
+          tag_name: ${{ steps.semver.outputs.version_tag }}
+          name: Release ${{ steps.semver.outputs.version_tag }}
           body: |
             Automated release based on PR labels/checklist.


### PR DESCRIPTION
This pull request includes a minor update to the `.github/workflows/release.yml` file to adjust the variables used for creating GitHub releases.

* [`.github/workflows/release.yml`](diffhunk://#diff-87db21a973eed4fef5f32b267aa60fcee5cbdf03c67fafdc2a9b553bb0b15f34L54-R55): Changed `tag_name` and `name` to use `steps.semver.outputs.version_tag` instead of `steps.semver.outputs.version` for better alignment with the naming convention.