### PR TITLE
Fix .pre-commit-config.yaml

### DIFF
--- a/testrepo/.pre-commit-config.yaml
+++ b/testrepo/.pre-commit-config.yaml
@@ -10,6 +10,7 @@ repos:
     rev: v0.9.0
     hooks:
       - id: shellcheck
+        language: system
 
   - repo: https://github.com/psf/black
     rev: 24.3.0


### PR DESCRIPTION
This pull request includes a small update to the `testrepo/.pre-commit-config.yaml` file. The change specifies the `language` as `system` for the `shellcheck` hook.