### PR TITLE
Add deepwiki badge to README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,6 +10,7 @@ Includes tools for packaging, linting, pre-commit checks, and CI integration.
 ![License](https://img.shields.io/github/license/the78mole/devkit-debian-package-build)
 ![Renovate](https://img.shields.io/badge/renovate-enabled-brightgreen?logo=renovatebot)
 
+[![Ask DeepWiki](https://deepwiki.com/badge.svg)](https://deepwiki.com/the78mole/devkit-debian-package-build)
 ---
 
 ## 🧰 Using as a Devcontainer


### PR DESCRIPTION
This pull request adds a new badge to the `README.md` file to highlight integration with DeepWiki.

* [`README.md`](diffhunk://#diff-b335630551682c19a781afebcf4d07bf978fb1f8ac04c6bf87428ed5106870f5R13): Added a DeepWiki badge linking to the project's page on DeepWiki.