### PR TITLE
Enable ko-fi sponsorship

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -3,7 +3,7 @@
 github: the78mole
 #patreon: # Replace with a single Patreon username
 #open_collective: # Replace with a single Open Collective username
-#ko_fi: # Replace with a single Ko-fi username
+ko-fi: the78mole
 #tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 #community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
 #liberapay: # Replace with a single Liberapay username


### PR DESCRIPTION
Aktiviert ko-fi-Spenden für diesen Repo mit dem Benutzername **the78mole**.

Änderung in `/.github/FUNDING.yml`:
- **Vorher:** `#ko_fi: # Replace with a single Ko-fi username`
- **Nachher:** `ko-fi: the78mole`

Dies wurde im Rahmen einer automatischen Aktualisierung aller FUNDING.yml-Dateien in meinem GitHub-Organisationsaccount erstellt.