### PR TITLE
Fix FUNDING.yml: ko-fi to ko_fi (underscore)

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -3,7 +3,7 @@
 github: the78mole
 #patreon: # Replace with a single Patreon username
 #open_collective: # Replace with a single Open Collective username
-ko-fi: the78mole
+ko_fi: the78mole
 #tidelift: # Replace with a single Tidelift platform-name/package-name e.g., npm/babel
 #community_bridge: # Replace with a single Community Bridge project-name e.g., cloud-foundry
 #liberapay: # Replace with a single Liberapay username
@@ -13,3 +13,4 @@ ko-fi: the78mole
 buy_me_a_coffee: the78mole
 #thanks_dev: # Replace with a single thanks.dev username
 #custom: # Replace with up to 4 custom sponsorship URLs e.g., ['link1', 'link2']
+


### PR DESCRIPTION
Korrigiert den Sponsor-Key in .github/FUNDING.yml:

- **Vorher:** `ko-fi: the78mole`
- **Nachher:** `ko_fi: the78mole`

Der korrekte Key für Ko-fi-Sponsorships in GitHub FUNDING.yml ist `ko_fi` (mit Unterstrich), nicht `ko-fi` (mit Bindestrich).